### PR TITLE
correct quoted instead of backticked column name

### DIFF
--- a/models/stg_stripe_plan.sql
+++ b/models/stg_stripe_plan.sql
@@ -15,7 +15,7 @@ with plan as (
       active as is_active,
       amount,
       currency,
-      "interval" as plan_interval,
+      `interval` as plan_interval,
       interval_count,
       nickname,
       product_id


### PR DESCRIPTION
I'm using BigQuery and noticed that in the `stripe_subscription_line_items` table that all non-null values for `plan_interval` were showing as the string `interval` rather than `year` or `month` as I expected. 

Caused by column name being escaped incorrectly.