### PR TITLE
readme and invoice field add updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ vars:
 ```
 
 ### Changing the Build Schema
-By default this package will build the Stripe staging models within a schema titled (<target_schema> + `_stg_stripe`). If this is not where you would like you Stripe staging to be written to, add the following configuration to your `dbt_project.yml` file:
+By default this package will build the Stripe staging models within a schema titled (<target_schema> + `_stg_stripe`). If this is not where you would like your Stripe staging models to be written to, add the following configuration to your `dbt_project.yml` file:
 
 ```yml
 # dbt_project.yml
@@ -56,7 +56,7 @@ By default this package will build the Stripe staging models within a schema tit
 ...
 models:
   stripe_source:
-    +schema: my_new_final_models_schema # leave blank for just the target_schema
+    +schema: my_new_staging_models_schema # leave blank for just the target_schema
 
 ```
 

--- a/models/stg_stripe__invoice_line_item.sql
+++ b/models/stg_stripe__invoice_line_item.sql
@@ -41,7 +41,9 @@ final as (
         subscription_id,
         subscription_item_id,
         type,
-        unique_id
+        unique_id,
+        period_start,
+        period_end
     from fields
     where id not like 'sub%' -- ids starting with 'sub' are temporary and are replaced by permanent ids starting with 'sli' 
 


### PR DESCRIPTION
This PR includes the following updates:

- README minor wording updates
- Added fields to the `stg_stripe__invoice_line_item` which are used in downstream models. These downstream effects can be seen within the [dbt_stripe PR #8](https://github.com/fivetran/dbt_stripe/pull/8)