### PR TITLE
backtick-fix

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'stripe_source'
-version: '0.3.0'
+version: '0.3.1'
 require-dbt-version: [">=0.18.0", "<0.20.0"]
 
 models:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'stripe_source_integration_tests'
-version: '0.3.0'
+version: '0.3.1'
 
 require-dbt-version: [">=0.18.0", "<0.20.0"]
 profile: 'integration_tests'

--- a/models/stg_stripe__plan.sql
+++ b/models/stg_stripe__plan.sql
@@ -34,7 +34,7 @@ final as (
         amount,
         currency,
         {% if target.type == 'bigquery' %}
-            'interval' as plan_interval,
+            `interval` as plan_interval,
         {% else %}
             interval as plan_interval,
         {% endif %}


### PR DESCRIPTION
This PR includes the following updates:

-  Addresses Issue #9  by updating the BigQuery reserved word conditional within the `stg_stripe__plan` model to use a back-tick opposed to a single quote in order to properly select the `interval` column.
- Upgrades the package version to v0.3.1