### PR TITLE
Filter out test and deleted Stripe customers from tmp view

### DIFF
--- a/models/tmp/stg_stripe__customer_tmp.sql
+++ b/models/tmp/stg_stripe__customer_tmp.sql
@@ -1,4 +1,4 @@
 select * 
 from {{ var('customer') }}
-where livemode = TRUE
-  and is_deleted = FALSE
+where livemode
+  and not is_deleted

--- a/models/tmp/stg_stripe__customer_tmp.sql
+++ b/models/tmp/stg_stripe__customer_tmp.sql
@@ -1,2 +1,4 @@
 select * 
 from {{ var('customer') }}
+where livemode = TRUE
+  and is_deleted = FALSE


### PR DESCRIPTION
Unsure if we need to go back and cast booleans as strings, so that these filters are warehouse-agnostic (e.g. [here in the macro for customer columns](https://github.com/fivetran/dbt_stripe_source/blob/0cfc3b4b91fede6d3f03d587da54e0272215ccc1/macros/get_customer_columns.sql#L24))

This works in Snowflake, though.