### PR TITLE
adding subscription_id in invoice table for use in the main stripe pa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# dbt_stripe_source v0.7.1
+## 🎉 Documentation and Feature Updates
+- Addition of subscription Id in the invoice tables
+- updating the get_invoice_columns.sql with subscription_id field and adding subscription_id in stg_stripe__invoice.sql for above change
 # dbt_stripe_source v0.7.0
 ## 🎉 Documentation and Feature Updates
 - Updated README documentation updates for easier navigation and setup of the dbt package

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -40,7 +40,7 @@ vars:
     using_subscriptions: true
 
     # variable to exclude or include historical subscription data
-    stripe__subscription_history: true
+    stripe__subscription_history: false
 
     # variable to exclude or include test data (based on `livemode`)
     using_livemode: true

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'stripe_source'
-version: '0.7.0'
+version: '0.7.1'
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 
@@ -31,6 +31,7 @@ vars:
     subscription: "{{ source('stripe', 'subscription') }}"
     credit_note: "{{ source('stripe', 'credit_note') }}"
     credit_note_line_item: "{{ source('stripe', 'credit_note_line_item') }}"
+    
 
     #Variables to enable or disable models if you do not have the respective table.
     using_invoices: true
@@ -39,7 +40,7 @@ vars:
     using_subscriptions: true
 
     # variable to exclude or include historical subscription data
-    stripe__subscription_history: false
+    stripe__subscription_history: true
 
     # variable to exclude or include test data (based on `livemode`)
     using_livemode: true

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'stripe_source_integration_tests'
-version: '0.7.0'
+version: '0.7.1'
 
 
 profile: 'integration_tests'

--- a/macros/get_invoice_columns.sql
+++ b/macros/get_invoice_columns.sql
@@ -41,6 +41,7 @@
     {"name": "status_transitions_marked_uncollectible_at", "datatype": dbt_utils.type_timestamp()},
     {"name": "status_transitions_paid_at", "datatype": dbt_utils.type_timestamp()},
     {"name": "status_transitions_voided_at", "datatype": dbt_utils.type_timestamp()},
+    {"name": "subscription_id", "datatype": dbt_utils.type_string()},
     {"name": "subscription_proration_date", "datatype": dbt_utils.type_int()},
     {"name": "subtotal", "datatype": dbt_utils.type_int()},
     {"name": "tax", "datatype": dbt_utils.type_int()},

--- a/models/src_stripe.yml
+++ b/models/src_stripe.yml
@@ -381,6 +381,8 @@ sources:
             description: This is the transaction number that appears on email receipts sent for this invoice.
           - name: status
             description: Status of the invoice.
+          - name: subscription_id
+            description: The ID of the subscription that the invoice item pertains to, if any.
           - name: subtotal
             description: Total of all subscriptions, invoice items, and prorations on the invoice before any discount or tax is applied.
           - name: tax

--- a/models/stg_stripe.yml
+++ b/models/stg_stripe.yml
@@ -369,6 +369,8 @@ models:
         description: This is the transaction number that appears on email receipts sent for this invoice.
       - name: status
         description: Status of the invoice.
+      - name: subscription_id
+        description: The ID of the subscription that the invoice item pertains to, if any.
       - name: subtotal
         description: Total of all subscriptions, invoice items, and prorations on the invoice before any discount or tax is applied.
       - name: tax

--- a/models/stg_stripe__invoice.sql
+++ b/models/stg_stripe__invoice.sql
@@ -50,8 +50,9 @@ final as (
         subtotal,
         tax,
         tax_percent,
-        total
-
+        total,
+        subscription_id
+        
         {% if var('stripe__invoice_metadata',[]) %}
         , {{ fivetran_utils.pivot_json_extract(string = 'metadata', list_of_properties = var('stripe__invoice_metadata')) }}
         {% endif %}


### PR DESCRIPTION
…ckage

Pull Request
**Are you a current Fivetran customer?** 
yes. Abine Inc

**What change(s) does this PR introduce?** 
Adds subscription_id to invoice table. 

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes

**Does this PR introduce a breaking change?**
- [ ] Yes (please provide breaking change details below.)
- [ ] No  (please provide an explanation as to how the change is non-breaking below.)
- [X] Unsure  (please provide an explanation as to how the change is non-breaking below.)
My stripe instance uses subscription. I am unsure if the Invoice object from stripe will always have the subscription_id column available based on your usage of subscriptions feature in stripe. 

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes, Issue/Feature #44 
- [X] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [X] Local (please provide additional testing details below)
![image](https://user-images.githubusercontent.com/104381621/170769242-161450cf-5afe-43ae-a32d-f86750def74b.png)

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] BigQuery
- [ ] Redshift
- [X] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:dancer:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
