### PR TITLE
Update does_table_exist.sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# dbt_stripe_source v0.14.1
+[PR #90](https://github.com/fivetran/dbt_stripe_source/pull/90) includes the following updates:
+
+## Under the Hood (Maintainers Only)  
+- Replaced call to adapter.get_relation with api.Relation.create in does_table_exist macro to prevent quoting bug
+
+
 # dbt_stripe_source v0.14.0
 [PR #89](https://github.com/fivetran/dbt_stripe_source/pull/89) includes the following updates:
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 config-version: 2
 name: 'stripe_source'
-version: '0.14.0'
+version: '0.14.1'
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 
 models:

--- a/macros/does_table_exist.sql
+++ b/macros/does_table_exist.sql
@@ -3,7 +3,7 @@
     {%- set ns = namespace(has_table=false) -%} -- declare boolean namespace and default value 
         {%- for node in graph.sources.values() -%} -- grab sources from the dictionary of nodes 
         -- call the database for the matching table
-            {%- set source_relation = adapter.get_relation(
+            {%- set source_relation = api.Relation.create(
                     database=node.database,
                     schema=node.schema,
                     identifier=node.identifier ) -%} 


### PR DESCRIPTION
Usage of adapter.get_relation causes a failure when fivetran/shopify package is also used in a project due to quoting of objects in that package.

Suggestion is to replace adapter.get_relation with api.Relation.create in this macro.

Please see:

https://github.com/oracle/dbt-oracle/issues/5#issuecomment-1166671800

**Please provide your name and company**

Corbett Barr, Sounds True (soundstrue.com)

**Detail what changes this PR introduces and how this addresses the issue/feature request linked above.**

Replace call to adapter.get_relation with api.Relation.create

**How did you validate the changes introduced within this PR?**

Forked and compiled successfully after changes.

**Which warehouse did you use to develop these changes?**

Snowflake

**Did you update the CHANGELOG?**
- [x] Yes

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)**
- [x] Yes

**Typically there are additional maintenance changes required before this will be ready for an upcoming release. Are you comfortable with the Fivetran team making a few commits directly to your branch?**
- [x] Yes
- [ ] No

**If you had to summarize this PR in an emoji, which would it be?**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:relieved:
